### PR TITLE
fix: remove extra quotation marks in first commit message

### DIFF
--- a/source/commands/init.ts
+++ b/source/commands/init.ts
@@ -28,7 +28,7 @@ export async function init(name: string, commandLineOptions: CreateCommandComman
 
   if (!gitDirectoryExists) {
     await execAndPrint('git', ['add', '--all'], path, commandLineOptions);
-    await execAndPrint('git', ['commit', '-m', '"feat: skaffold"'], path, commandLineOptions);
+    await execAndPrint('git', ['commit', '-m', 'feat: skaffold'], path, commandLineOptions);
     await execAndPrint('git', ['checkout', '-b', 'dev'], path, commandLineOptions);
   }
 


### PR DESCRIPTION
### Description

When creating a new project, the first commit message contains extra quotation marks breaking the Conventional Commits specification.

Here is what the first commit message of [zoxy](https://github.com/skarab42/zoxy) looks like on GitHub for example:

<img width="923" alt="Screenshot 2022-12-13 at 16 02 42" src="https://user-images.githubusercontent.com/494699/207369642-c68e0e87-a48f-4c1f-b350-5bd46a915d9b.png">

### Additional context

The [execa `shell` option](https://github.com/sindresorhus/execa#shell) is not used when running commands meaning the command is executed outside of a shell where no escaping is needed. Therefore, the double quotation marks were interpreted as part of the commit message.

Here is a side-by-side comparison of running the script before and after the change and checking the git logs:

<img width="1176" alt="before-after" src="https://user-images.githubusercontent.com/494699/207370347-61f1f66d-39bd-4af3-a321-b31a351ece71.png">

